### PR TITLE
fix: timezone warning

### DIFF
--- a/commands/post_new.php
+++ b/commands/post_new.php
@@ -11,10 +11,16 @@
   $task_id = $strings[1];
   $project = str_replace("_", " ", $strings[2]);
 
-  // get timezone from system and format date: 
-  $tz_string = exec('systemsetup -gettimezone');
-  $tz = substr( $tz_string, ( strpos( $tz_string, ": " ) + 2 ) );
+  $default_tz = "UTC";
+  $tz_file = readlink("/etc/localtime");
+  $pos = strpos($tz_file, "zoneinfo");
+  if ($pos) {
+    $tz = substr($tz_file, $pos + strlen("zoneinfo/"));
+  } else {
+    $tz = $default_tz;
+  }
   date_default_timezone_set( $tz );
+
   $date = date("D, d M Y");
 
   // set xml_data to post to Harvest API:

--- a/commands/post_note.php
+++ b/commands/post_note.php
@@ -11,9 +11,14 @@
     $entry_project_id = $strings[3];
     $entry_task_id = $strings[4];
 
-    // set default timezone to avoid warnings
-    $tz_string = exec('systemsetup -gettimezone');
-    $tz = substr( $tz_string, ( strpos( $tz_string, ": " ) + 2 ) );
+    $default_tz = "UTC";
+    $tz_file = readlink("/etc/localtime");
+    $pos = strpos($tz_file, "zoneinfo");
+    if ($pos) {
+      $tz = substr($tz_file, $pos + strlen("zoneinfo/"));
+    } else {
+      $tz = $default_tz;
+    }
     date_default_timezone_set( $tz );
     // reformat $entry_spent_at for posting to Harvest API
     $entry_spent_at = date_create_from_format("Y-m-d", $entry_spent_at);


### PR DESCRIPTION
Addresses #9 

`systemsetup -gettimezone` now requires sudo access. Rather than requiring that users type their password, I'm reading the time zone variable from `/etc/localtime`.
