### PR TITLE
Handle setup not being complete yet

### DIFF
--- a/commands/auth.php
+++ b/commands/auth.php
@@ -1,7 +1,21 @@
 <?php
 
   $dir = "../../../Workflow Data/com.neilrenicker.harvest/";
-  $fp = fopen($dir . "id.txt", "r");
+  $idPath = $dir . "id.txt";
+
+  if(!file_exists($idPath)) {
+    $xml = "<?xml version=\"1.0\"?>\n<items>\n";
+    $xml .= "<item uid=\"harvestaccount\" arg=\"$url\">\n";
+    $xml .= "<title>Run hv setup to authenticate first</title>\n";
+    $xml .= "<subtitle>Required before you can run commands</subtitle>\n";
+    $xml .= "<icon>icon.png</icon>\n";
+    $xml .= "</item>\n";
+    $xml .= "</items>";
+    echo $xml;
+    die();
+  }
+
+  $fp = fopen($idPath, "r");
   $data = stream_get_contents($fp);
   fclose($fp);
 


### PR DESCRIPTION
If you're not authenticated yet, instead of throwing PHP errors, which leads to invalid XML and the workflow crashing (see below) remind the user to 'setup' first.

This should work for all commands.
Fixes #20

Previous error message:

```
[ERROR: alfred.workflow.input.scriptfilter] XML Parse Error 'The operation couldn’t be completed. (NSXMLParserErrorDomain error 4.)'. Row (null), Col (null): 'Document is empty' in XML:
Warning: fopen(../../../Workflow Data/com.neilrenicker.harvest/id.txt): failed to open stream: No such file or directory in Alred/Alfred.alfredpreferences/workflows/user.workflow.FC9CD668-0E69-43A1-9876-962C81B7318F/commands/auth.php on line 6
Warning: stream_get_contents() expects parameter 1 to be resource, boolean given in Alred/Alfred.alfredpreferences/workflows/user.workflow.FC9CD668-0E69-43A1-9876-962C81B7318F/commands/auth.php on line 7
Warning: fclose() expects parameter 1 to be resource, boolean given in Alred/Alfred.alfredpreferences/workflows/user.workflow.FC9CD668-0E69-43A1-9876-962C81B7318F/commands/auth.php on line 8
```
